### PR TITLE
Make plugin configuration available at build time

### DIFF
--- a/config/mwdb.ini
+++ b/config/mwdb.ini
@@ -3,8 +3,6 @@
 [mwdb]
 
 secret_key = mwdb-secret-key
-enable_plugins = 1
-plugins = mwdb_plugin_karton
 storage_provider = s3
 hash_pathing = 0
 s3_storage_endpoint = minio:9000

--- a/docker/Dockerfile-mwdb
+++ b/docker/Dockerfile-mwdb
@@ -11,5 +11,8 @@ COPY docker/uwsgi.ini docker/start.sh /app/
 WORKDIR /app
 # Make fresh web build including plugins
 ENV MWDB_WEB_FOLDER /app/web
+ENV MWDB_ENABLE_PLUGINS 1
+ENV MWDB_PLUGINS mwdb_plugin_karton
+
 RUN mwdb-core configure web
 CMD ["/app/start.sh"]


### PR DESCRIPTION
Plugin configuration is not available build-time, so `mwdb-core configure web` doesn't include plugin in web app code.