### PR TITLE
Upgrade karton-playground to Karton v5.0.0

### DIFF
--- a/config/karton.docker.ini
+++ b/config/karton.docker.ini
@@ -1,12 +1,11 @@
 [redis]
 host=redis
 
-[minio]
+[s3]
 access_key = mwdb
 secret_key = mwdbmwdb
-address = minio:9000
+address = http://minio:9000
 bucket = karton
-secure = 0
 
 [mwdb]
 api_url = http://mwdb.:8080/api/

--- a/config/karton.ini
+++ b/config/karton.ini
@@ -2,12 +2,11 @@
 host=localhost
 port=8379
 
-[minio]
+[s3]
 secret_key = mwdbmwdb
 access_key = mwdb
-address = localhost:8090
+address = http://localhost:8090
 bucket = karton
-secure = 0
 
 [mwdb]
 api_url=http://localhost:8080/api/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
   karton-system:
-    image: certpl/karton-system:cb68f9fd7a5e9dc6b6a8538d71ebc0e43f5cc69c
+    image: certpl/karton-system:v5.0.0
     depends_on:
       - redis
       - minio
@@ -47,14 +47,14 @@ services:
     entrypoint: karton-system
     command: --setup-bucket
   karton-classifier:
-    image: certpl/karton-classifier:84c642c666334db3df66b98752784c2044aa3c2d
+    image: certpl/karton-classifier:v1.4.0
     depends_on:
       - redis
       - minio
     volumes:
       - ./config/karton.docker.ini:/etc/karton/karton.ini
   karton-dashboard:
-    image: certpl/karton-dashboard:8f5bdd94bed2ddff2ef4a826f8107a8ec11e8609
+    image: certpl/karton-dashboard:v1.4.0
     depends_on:
       - redis
       - minio
@@ -63,9 +63,10 @@ services:
     ports:
       - "127.0.0.1:8030:5000"
   karton-mwdb-reporter:
-    image: certpl/karton-mwdb-reporter:1afa32251b4826eac4386596b4a20f295699faec
+    image: certpl/karton-mwdb-reporter:v1.2.0
     depends_on:
       - redis
       - minio
     volumes:
       - ./config/karton.docker.ini:/etc/karton/karton.ini
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3.3"
 services:
   minio:
     image: minio/minio
-    command: "server --address 0.0.0.0:9000 --console-address :8070 /data"
+    entrypoint: sh
+    command: -c "mkdir -p /data/mwdb && minio server --address 0.0.0.0:9000 --console-address :8070 /data"
     environment:
       MINIO_ACCESS_KEY: mwdb
       MINIO_SECRET_KEY: mwdbmwdb
@@ -38,7 +39,7 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
   karton-system:
-    image: certpl/karton-system:v5.0.0
+    image: certpl/karton-system:v5.1.0
     depends_on:
       - redis
       - minio

--- a/docker/Dockerfile-mwdb
+++ b/docker/Dockerfile-mwdb
@@ -1,8 +1,8 @@
-FROM python:3.8
+FROM python:3.10
 
 RUN apt update && apt install -y build-essential libffi-dev libfuzzy-dev postgresql-client libmagic1
 
-RUN pip install mwdb-core==2.7.0 karton-core==4.3.0
+RUN pip install mwdb-core==2.8.2 karton-core==5.0.0
 
 COPY docker/uwsgi.ini docker/start.sh /app/
 

--- a/docker/karton.local.ini
+++ b/docker/karton.local.ini
@@ -1,9 +1,8 @@
-[minio]
+[s3]
 secret_key = mwdbmwdb
 access_key = mwdb
-address = localhost:8090
+address = http://localhost:8090
 bucket = karton
-secure = 0
 
 [redis]
 host=localhost


### PR DESCRIPTION
mwdb-core must be still on v4.3.0 because it's hard-pinned. Will be upgraded in next mwdb-core release.