### PR TITLE
Fix MinIO healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,9 @@ services:
       - "127.0.0.1:8090:9000"
       - "127.0.0.1:8070:8070"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
+      test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
+      interval: 5s
+      timeout: 5s
       retries: 3
   postgres:
     image: postgres:13.1


### PR DESCRIPTION
MinIO switched base images some time ago[1]. That removed the curl binary and broke the healthcheck we use in our compose file.

[1] https://github.com/minio/minio/issues/18373