### PR TITLE
Ping static resource instead of varz in karton-dashboard healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
     ports:
       - "127.0.0.1:8030:5000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/varz"]
+      test: ["CMD", "curl", "-f", "http://localhost:5000/static/bootstrap.css"]
       interval: 30s
       timeout: 20s
       retries: 3


### PR DESCRIPTION
Hello!

Pinging /varz erases some of metrics that will be harmful for prometheus.

This PR suggests to ping static css file, it is also an indicator that dashboard is up.