### PR TITLE
Split karton-system to router and gc parts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       interval: 30s
       timeout: 20s
       retries: 3
-  karton-system:
+  karton-system-router:
     image: certpl/karton-system:v5.5.1
     depends_on:
       minio:
@@ -79,7 +79,16 @@ services:
     volumes:
       - ./config/karton.docker.ini:/etc/karton/karton.ini
     entrypoint: karton-system
-    command: --setup-bucket
+    command: --setup-bucket --disable-gc
+  karton-system-gc:
+    image: certpl/karton-system:v5.5.1
+    depends_on:
+      karton-system-router:
+        condition: service_started
+    volumes:
+      - ./config/karton.docker.ini:/etc/karton/karton.ini
+    entrypoint: karton-system
+    command: --disable-router
   karton-classifier:
     image: certpl/karton-classifier:v2.0.0
     depends_on:


### PR DESCRIPTION
Hello!

This PR introduces a small optimization suggested by @psrok1 to avoid GC stalls
(https://github.com/CERT-Polska/karton/issues/291#issuecomment-3216919907).

I benchmarked it on Karton 5.9.0 with the following settings:
- Redis 8.4.0
- MinIO RELEASE.2025-09-07T16-13-09Z
- 16 workers
- 10,000 tasks, repeated 200 times
- each task has a 100 KB payload

With a 1-minute warm-up and an overall task duration of 11 minutes,
we can clearly observe pauses caused by GC runs occurring every ~3 minutes:

<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/599665c9-5c34-478f-9e40-58f5553c366b" />
<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/016b3460-6803-47ff-bfbe-4b5d50b053ec" />
<img width="1000" height="500" alt="image" src="https://github.com/user-attachments/assets/5c91646c-3454-425e-a976-aa911c5f6cdb" />

With this change, GC stalls are eliminated, resulting in a ~2.8% increase
in maximum throughput per GC cycle in this benchmark.
